### PR TITLE
qtshadertools 6.7.2

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,10 @@
+build_parameters:
+  - "--suppress-variables"
+  - "--error-overlinking"
+
+aggregate_check: false
+
+channels:
+  - rafaelmartins-qt
+
+upload_without_merge: true

--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -1,0 +1,21 @@
+cmake -S"%SRC_DIR%/%PKG_NAME%" -B"%SRC_DIR%\build" -GNinja ^
+    -DCMAKE_BUILD_TYPE=Release ^
+    -DCMAKE_PREFIX_PATH="%LIBRARY_PREFIX%" ^
+    -DCMAKE_INSTALL_PREFIX="%LIBRARY_PREFIX%" ^
+    -DINSTALL_BINDIR=lib/qt6/bin ^
+    -DINSTALL_PUBLICBINDIR=bin ^
+    -DINSTALL_LIBEXECDIR=lib/qt6 ^
+    -DINSTALL_DOCDIR=share/doc/qt6 ^
+    -DINSTALL_ARCHDATADIR=lib/qt6 ^
+    -DINSTALL_DATADIR=share/qt6 ^
+    -DINSTALL_INCLUDEDIR=include/qt6 ^
+    -DINSTALL_MKSPECSDIR=lib/qt6/mkspecs ^
+    -DINSTALL_EXAMPLESDIR=share/doc/qt6/examples ^
+    -DINSTALL_DATADIR=share/qt6
+if errorlevel 1 exit 1
+
+cmake --build build --target install
+if errorlevel 1 exit 1
+
+xcopy /y /s %LIBRARY_PREFIX%\lib\qt6\bin\*.dll %LIBRARY_PREFIX%\bin
+if errorlevel 1 exit 1

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -1,0 +1,35 @@
+#!/bin/sh
+
+set -ex
+
+cmake -S"${SRC_DIR}/${PKG_NAME}" -Bbuild -GNinja ${CMAKE_ARGS} \
+  -DCMAKE_PREFIX_PATH=${PREFIX} \
+  -DCMAKE_INSTALL_PREFIX=${PREFIX} \
+  -DCMAKE_INSTALL_RPATH=${PREFIX}/lib \
+  -DCMAKE_BUILD_WITH_INSTALL_RPATH=ON \
+  -DCMAKE_FIND_FRAMEWORK=LAST \
+  -DBUILD_WITH_PCH=OFF \
+  -DINSTALL_BINDIR=lib/qt6/bin \
+  -DINSTALL_PUBLICBINDIR=bin \
+  -DINSTALL_LIBEXECDIR=lib/qt6 \
+  -DINSTALL_DOCDIR=share/doc/qt6 \
+  -DINSTALL_ARCHDATADIR=lib/qt6 \
+  -DINSTALL_DATADIR=share/qt6 \
+  -DINSTALL_INCLUDEDIR=include/qt6 \
+  -DINSTALL_MKSPECSDIR=lib/qt6/mkspecs \
+  -DINSTALL_EXAMPLESDIR=share/doc/qt6/examples
+cmake --build build --target install
+
+pushd "${PREFIX}"
+
+mkdir -p bin
+
+if [[ -f "${SRC_DIR}"/build/user_facing_tool_links.txt ]]; then
+  for links in "${SRC_DIR}"/build/user_facing_tool_links.txt; do
+    while read _line; do
+      if [[ -n "${_line}" ]]; then
+        ln -sf ${_line}
+      fi
+    done < ${links}
+  done
+fi

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -1,0 +1,11 @@
+MACOSX_SDK_VERSION:
+  - '11.3'                                                   # [osx]
+CONDA_BUILD_SYSROOT:
+  - /Library/Developer/CommandLineTools/SDKs/MacOSX11.3.sdk  # [osx]
+c_compiler:
+  - vs2019  # [win]
+cxx_compiler:
+  - vs2019  # [win]
+macos_machine:
+  - x86_64-apple-darwin20.0.0  # [osx and x86_64]
+  - arm64-apple-darwin20.0.0   # [osx and arm64]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,0 +1,112 @@
+{% set name = "qtshadertools" %}
+{% set version = "6.7.2" %}
+
+package:
+  name: {{ name }}
+  version: {{ version }}
+
+source:
+  - url: https://download.qt.io/official_releases/qt/{{ version.rpartition('.')[0] }}/{{ version }}/submodules/{{ name }}-everywhere-src-{{ version }}.tar.xz
+    sha256: edfa34c0ac8c00fcaa949df1d8e7a77d89dadd6386e683ce6c3e3b117e2f7cc1
+    folder: {{ name }}
+
+build:
+  number: 0
+  skip: True  # [ppc64le or s390x]
+  run_exports:
+    - {{ pin_subpackage(name, max_pin='x.x') }}
+
+requirements:
+  build:
+    - {{ compiler('c') }}
+    - {{ compiler('cxx') }}
+    - {{ cdt('libdrm-devel') }}               # [linux]
+    - {{ cdt('libglvnd-glx') }}               # [linux and not x86_64]
+    - {{ cdt('libglvnd-egl') }}               # [linux and not x86_64]
+    - {{ cdt('libice-devel') }}               # [linux]
+    - {{ cdt('libsm-devel') }}                # [linux]
+    - {{ cdt('libx11-devel') }}               # [linux]
+    - {{ cdt('libxau-devel') }}               # [linux]
+    - {{ cdt('mesa-libgl-devel') }}           # [linux]
+    - {{ cdt('mesa-libgbm') }}                # [linux]
+    - {{ cdt('mesa-libegl-devel') }}          # [linux]
+    - {{ cdt('mesa-dri-drivers') }}           # [linux]
+    - {{ cdt('xcb-util-devel') }}             # [linux]
+    - {{ cdt('xcb-util-image-devel') }}       # [linux]
+    - {{ cdt('xcb-util-keysyms-devel') }}     # [linux]
+    - {{ cdt('xcb-util-renderutil-devel') }}  # [linux]
+    - {{ cdt('xcb-util-wm-devel') }}          # [linux]
+    - {{ cdt('xorg-x11-proto-devel') }}       # [linux]
+    - {{ cdt('libselinux') }}                 # [linux]
+    - {{ cdt('libxext') }}                    # [linux]
+    - {{ cdt('libxdamage') }}                 # [linux]
+    - {{ cdt('libxfixes') }}                  # [linux]
+    - {{ cdt('libxxf86vm') }}                 # [linux]
+    - pkg-config  # [unix]
+    - bison       # [linux]
+    - flex        # [linux]
+    - gperf       # [linux]
+    - jom         # [win]
+    - m2-bison    # [win]
+    - m2-flex     # [win]
+    - m2-gperf    # [win]
+    - cmake
+    - ninja
+    - perl
+
+  host:
+    - qtbase {{ version }}
+
+  run_constrained:
+    - qt-main >={{ version }},<7
+    - qt >={{ version }},<7
+
+test:
+  requires:
+    # we don't really need a compiler for testing the qsb binary, but the activation scripts help us load the CDT libraries correctly
+    - {{ compiler('cxx') }}                   # [linux]
+    - {{ cdt('libdrm-devel') }}               # [linux]
+    - {{ cdt('libglvnd-glx') }}               # [linux and not x86_64]
+    - {{ cdt('libglvnd-egl') }}               # [linux and not x86_64]
+    - {{ cdt('libice-devel') }}               # [linux]
+    - {{ cdt('libsm-devel') }}                # [linux]
+    - {{ cdt('libx11-devel') }}               # [linux]
+    - {{ cdt('libxau-devel') }}               # [linux]
+    - {{ cdt('mesa-libgl-devel') }}           # [linux]
+    - {{ cdt('mesa-libgbm') }}                # [linux]
+    - {{ cdt('mesa-libegl-devel') }}          # [linux]
+    - {{ cdt('mesa-dri-drivers') }}           # [linux]
+    - {{ cdt('xcb-util-devel') }}             # [linux]
+    - {{ cdt('xcb-util-image-devel') }}       # [linux]
+    - {{ cdt('xcb-util-keysyms-devel') }}     # [linux]
+    - {{ cdt('xcb-util-renderutil-devel') }}  # [linux]
+    - {{ cdt('xcb-util-wm-devel') }}          # [linux]
+    - {{ cdt('xorg-x11-proto-devel') }}       # [linux]
+    - {{ cdt('libselinux') }}                 # [linux]
+    - {{ cdt('libxext') }}                    # [linux]
+    - {{ cdt('libxdamage') }}                 # [linux]
+    - {{ cdt('libxfixes') }}                  # [linux]
+    - {{ cdt('libxxf86vm') }}                 # [linux]
+  commands:
+    # no public api to test
+    {% for each_qt_lib in ["ShaderTools"] %}
+    - test -d $PREFIX/include/qt6/Qt{{ each_qt_lib }}                           # [unix]
+    - test -f $PREFIX/lib/libQt6{{ each_qt_lib }}${SHLIB_EXT}                   # [unix]
+    - if not exist %PREFIX%\\Library\\include\\qt6\\Qt{{ each_qt_lib }} exit 1  # [win]
+    - if not exist %PREFIX%\\Library\\lib\\Qt6{{ each_qt_lib }}.lib exit 1      # [win]
+    - if not exist %PREFIX%\\Library\\bin\\Qt6{{ each_qt_lib }}.dll exit 1      # [win]
+    {% endfor %}
+    - LD_LIBRARY_PATH="${PREFIX}/${HOST}/sysroot/usr/lib64:${PREFIX}/${HOST}/sysroot/usr/lib:${LD_LIBRARY_PATH}" ${PREFIX}/lib/qt6/bin/qsb --version  # [unix]
+    - "%PREFIX%\\Library\\lib\\qt6\\bin\\qsb --version"  # [win]
+
+about:
+  home: https://www.qt.io/
+  license: LGPL-3.0-only
+  license_file: {{ name }}/LICENSES/LGPL-3.0-only.txt
+  license_family: LGPL
+  summary: Cross-platform application and UI framework ({{ name[2:] }} libraries).
+  description: |
+    Qt helps you create connected devices, UIs & applications that run
+    anywhere on any device, on any operating system at any time ({{ name[2:] }} libraries).
+  doc_url: https://doc.qt.io/
+  dev_url: https://github.com/qt/{{ name }}


### PR DESCRIPTION
qtshadertools 6.7.2

**Destination channel:** defaults

### Links

- [PKG-5188](https://anaconda.atlassian.net/browse/PKG-5188) 
- [Upstream repository](https://github.com/qt/qtshadertools)
- Relevant dependency PRs:
  - https://github.com/AnacondaRecipes/clang-compiler-activation-feedstock/pull/4
  - https://github.com/AnacondaRecipes/tapi-feedstock/pull/3
  - https://github.com/AnacondaRecipes/cctools-and-ld64-feedstock/pull/3
  - https://github.com/AnacondaRecipes/qtbase-feedstock/pull/2
  - https://github.com/AnacondaRecipes/qtsvg-feedstock/pull/1

### Explanation of changes:

- Major upgrade to qt 6.7.2, splitted qt-main into several recipes.


[PKG-5188]: https://anaconda.atlassian.net/browse/PKG-5188?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ