### PR TITLE
qtshadertools 6.10.2

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,2 +1,0 @@
-channels:
-  - https://staging.continuum.io/pbp/fs/qtbase-feedstock/pr21/901c992

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,2 @@
+channels:
+  - https://staging.continuum.io/pbp/fs/qtbase-feedstock/pr21/901c992

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "qtshadertools" %}
-{% set version = "6.10.1" %}
+{% set version = "6.10.2" %}
 
 package:
   name: {{ name }}
@@ -7,7 +7,7 @@ package:
 
 source:
   - url: https://download.qt.io/official_releases/qt/{{ version.rpartition('.')[0] }}/{{ version }}/submodules/{{ name }}-everywhere-src-{{ version }}.tar.xz
-    sha256: b67894a63352b53dad0d46f5300c62b8cd6783db575492d6b25d4fdc9af55bb6
+    sha256: 18d9dbbc4f7e6e96e6ed89a9965dc032e2b58158b65156c035537826216716c9
     folder: {{ name }}
 
 build:


### PR DESCRIPTION
qtshadertools 6.10.2

**Destination channel:** defaults

### Links

- [PKG-12473](https://anaconda.atlassian.net/browse/PKG-12473) 


### Explanation of changes:

- Version update


[PKG-12473]: https://anaconda.atlassian.net/browse/PKG-12473?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ